### PR TITLE
尝试支持 napi-rs/canvas

### DIFF
--- a/packages/interface/src/canvas/ISkiaCanvas.ts
+++ b/packages/interface/src/canvas/ISkiaCanvas.ts
@@ -1,6 +1,6 @@
 import { IExportFileType, IExportImageType } from '../file/IFileType'
 
-export type ICanvasType = 'skia' | 'canvas' | 'wx'
+export type ICanvasType = 'skia' | 'napi' | 'canvas' | 'wx'
 
 export interface ISkiaCanvas {
     toBuffer(format: IExportFileType, config: ISkiaCanvasExportConfig): Promise<any>
@@ -9,6 +9,19 @@ export interface ISkiaCanvas {
     toDataURLSync(format: IExportImageType, config: ISkiaCanvasExportConfig): string
     saveAs(filename: string, config: ISkiaCanvasExportConfig): Promise<void>
     saveAsSync(filename: string, config: ISkiaCanvasExportConfig): void
+}
+
+export interface INapiCanvas {
+    encode(format: 'webp' | 'jpeg', quality?: number): Promise<any>
+    encode(format: 'png'): Promise<any>
+    toBuffer(mime: 'image/png'): any
+    toBuffer(mime: 'image/jpeg' | 'image/webp', quality?: number): any
+    toDataURL(mime?: 'image/png'): string
+    toDataURL(mime: 'image/jpeg' | 'image/webp', quality?: number): string
+    toDataURL(mime?: 'image/jpeg' | 'image/webp' | 'image/png', quality?: number): string
+    toDataURLAsync(mime?: 'image/png'): Promise<string>
+    toDataURLAsync(mime: 'image/jpeg' | 'image/webp', quality?: number): Promise<string>
+    toDataURLAsync(mime?: 'image/jpeg' | 'image/webp' | 'image/png', quality?: number): Promise<string>
 }
 
 export interface ISkiaCanvasExportConfig {

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -35,7 +35,7 @@ export { IPlugin } from './plugin/IPlugin'
 
 
 export { ILeaferCanvas, IHitCanvas, ICanvasAttr, ICanvasStrokeOptions, ILeaferCanvasConfig, IHitCanvasConfig, IBlobFunction, IBlob } from './canvas/ILeaferCanvas'
-export { ISkiaCanvas, ISkiaCanvasExportConfig, ICanvasType } from './canvas/ISkiaCanvas'
+export { ISkiaCanvas, INapiCanvas, ISkiaCanvasExportConfig, ICanvasType } from './canvas/ISkiaCanvas'
 export { IPathDrawer, IPathCreator } from './path/IPathDrawer'
 export { IWindingRule, ICanvasContext2D, ITextMetrics, IPath2D } from './canvas/ICanvas'
 export { CanvasPathCommand, IPathCommandData, MCommandData, HCommandData, VCommandData, LCommandData, CCommandData, SCommandData, QCommandData, TCommandData, ZCommandData, ACommandData, RectCommandData, RoundRectCommandData, EllipseCommandData, ArcCommandData, ArcToCommandData } from './path/IPathCommand'

--- a/packages/platform/node/package.json
+++ b/packages/platform/node/package.json
@@ -22,6 +22,7 @@
     "@leafer/canvas-node": "1.0.0-beta.9",
     "@leafer/interaction": "1.0.0-beta.9",
     "@leafer/image-node": "1.0.0-beta.9"
+    "@types/node": "^18.15.3"
   },
   "devDependencies": {
      "@leafer/interface": "1.0.0-beta.9"

--- a/packages/platform/node/src/index.ts
+++ b/packages/platform/node/src/index.ts
@@ -46,7 +46,7 @@ export function useCanvas(canvasType: ICanvasType, power: IObject): void {
                     if (type == "png") return canvas.toBuffer('image/png')
                     return canvas.toBuffer(`image/${type == "jpg" ? "jpeg" : type}`, quality)
                 },
-                canvasSaveAs: (canvas: INapiCanvas, filename: string, quality?: any) => canvas.encode("png").then(data => promises.writeFile(join(__dirname, filename), data)),
+                canvasSaveAs: (canvas: INapiCanvas, filename: string, quality?: any) => canvas.encode("png").then(data => promises.writeFile(join(filename), data)),
                 loadImage
             }
         }

--- a/packages/platform/node/src/index.ts
+++ b/packages/platform/node/src/index.ts
@@ -4,12 +4,15 @@ export * from '@leafer/partner'
 export * from '@leafer/canvas-node'
 export * from '@leafer/image-web'
 
-import { ICanvasType, ICreator, IExportFileType, IExportImageType, IFunction, IObject, ISkiaCanvas } from '@leafer/interface'
+import { ICanvasType, ICreator, IExportFileType, IExportImageType, IFunction, IObject, ISkiaCanvas, INapiCanvas } from '@leafer/interface'
 import { Platform, Creator } from '@leafer/core'
 
 import { LeaferCanvas } from '@leafer/canvas-node'
 import { LeaferImage } from '@leafer/image-node'
 import { InteractionBase } from '@leafer/interaction'
+// napi-canvas
+import {promises} from "fs";
+import {join} from "path";
 
 
 Object.assign(Creator, {
@@ -30,6 +33,20 @@ export function useCanvas(canvasType: ICanvasType, power: IObject): void {
                 canvasToDataURL: (canvas: ISkiaCanvas, type?: IExportImageType, quality?: number) => canvas.toDataURLSync(type, { quality }),
                 canvasToBolb: (canvas: ISkiaCanvas, type?: IExportFileType, quality?: number) => canvas.toBuffer(type, { quality }),
                 canvasSaveAs: (canvas: ISkiaCanvas, filename: string, quality?: any) => canvas.saveAs(filename, { quality }),
+                loadImage
+            }
+        }
+
+        if (canvasType === 'napi') {
+            const { Canvas, loadImage } = power
+            Platform.origin = {
+                createCanvas: (width: number, height: number, format?: string) => new Canvas(width, height, format),
+                canvasToDataURL: (canvas: INapiCanvas, type?: IExportImageType, quality?: number) => canvas.toDataURL(`image/${type == "jpg" ? "jpeg" : type}`, quality),
+                canvasToBolb: (canvas: INapiCanvas, type?: IExportImageType, quality?: number) => {
+                    if (type == "png") return canvas.toBuffer('image/png')
+                    return canvas.toBuffer(`image/${type == "jpg" ? "jpeg" : type}`, quality)
+                },
+                canvasSaveAs: (canvas: INapiCanvas, filename: string, quality?: any) => canvas.encode("png").then(data => promises.writeFile(join(__dirname, filename), data)),
                 loadImage
             }
         }


### PR DESCRIPTION
简单添加了 https://github.com/Brooooooklyn/canvas 的支持
其实大部分和 skia 是一致的，直接 useCanvas('skia', require('@napi-rs/canvas')) 遇到的问题只有 toDataURLSync 不存在和图像类型不匹配(jpg -> jpeg)，我自己尝试暴力改 node_modules 里 leafer 的所有 js 文件中的 toDataURLSync 为 toDataURL 就能用了

类型摘自这里 https://github.com/Brooooooklyn/canvas/blob/main/index.d.ts#L354
实现很粗糙，希望大佬能支持一下这个 Node 上 0 系统依赖的 Canvas，这个 PR 仅作抛砖引玉用