### PR TITLE
Fix:修复微信小程序保存到相册时resolve时机提前的问题

### DIFF
--- a/packages/platform/miniapp/src/index.ts
+++ b/packages/platform/miniapp/src/index.ts
@@ -46,9 +46,12 @@ export function useCanvas(_canvasType: ICanvasType, app?: IObject): void {
                             if (toAlbum) {
                                 Platform.miniapp.saveToAlbum(filePath).then(() => {
                                     fs.unlink({ filePath })
+                                    resolve()
                                 })
+                            }else {
+                                resolve()
                             }
-                            resolve()
+                            
                         },
                         fail(error: any) {
                             reject(error)


### PR DESCRIPTION
```
leaferSave.export(`custom_${nowTime}.png`).then(res => {
            console.log(res)
            wx.showToast({
                title: '保存成功',
            })
        })
```
修复前：没有保存成功toast依然会出现or保存成功但toast 在保存成功之前出现
修复后：toast出现时机在保存到相册之后，符合预期